### PR TITLE
Remove `tsconfig.build.tsbuildinfo` from publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "3.0.0",
   "license": "MIT",
   "files": [
-    "./dist"
+    "./dist",
+    "!dist/tsconfig.build.tsbuildinfo"
   ],
   "exports": "./dist/plugin.js",
   "types": "./dist/plugin.d.ts",


### PR DESCRIPTION
It was published in `dist/tsconfig.build.tsbuildinfo` but not needed. It's used by TypeScript to cache in-between builds only.