### PR TITLE
Fix smart quotes at the start of paragraphs

### DIFF
--- a/plugin.test.ts
+++ b/plugin.test.ts
@@ -60,6 +60,13 @@ describe("handles quotes around inline code", async () => {
   });
 });
 
+it("handles quotes after blockquotes", async () => {
+  const file = await process('> blockquote \n\n"after blockquote"');
+  expect(file.toString()).toMatchInlineSnapshot(`
+    "> blockquote \n\n“after blockquote”"
+    "`);
+});
+
 describe("should ignore parent nodes", () => {
   const mdxCompiler = remark().use(remarkMdx).use(remarkSmartypants);
   const process = mdxCompiler.process.bind(mdxCompiler);

--- a/plugin.test.ts
+++ b/plugin.test.ts
@@ -61,9 +61,9 @@ describe("handles quotes around inline code", async () => {
 });
 
 it("handles quotes after blockquotes", async () => {
-  const file = await process('> blockquote \n\n"after blockquote"');
+  const file = await process('> blockquote\n\n"after blockquote"');
   expect(file.toString()).toMatchInlineSnapshot(`
-    "> blockquote \n\n“after blockquote”"
+    "> blockquote\n\n“after blockquote”
     "`);
 });
 

--- a/plugin.test.ts
+++ b/plugin.test.ts
@@ -60,25 +60,39 @@ describe("handles quotes around inline code", async () => {
   });
 });
 
-describe("handles quotes at the start of a paragraph", () => {
-  it("after paragraphs", async () => {
+describe("handles quotes at the edges of a paragraph", () => {
+  it("at start after another paragraph", async () => {
     const file = await process('paragraph\n\n"after paragraph"');
     expect(file.toString()).toMatchInlineSnapshot(`
       "paragraph\n\n“after paragraph”
       "`);
   });
 
-  it("after a blockquote", async () => {
+  it("at start after a blockquote", async () => {
     const file = await process('> blockquote\n\n"after blockquote"');
     expect(file.toString()).toMatchInlineSnapshot(`
       "> blockquote\n\n“after blockquote”
       "`);
   });
 
-  it("within a blockquote", async () => {
+  it("at start within a blockquote", async () => {
     const file = await process('> blockquote\n>\n> "within blockquote"');
     expect(file.toString()).toMatchInlineSnapshot(`
       "> blockquote\n>\n> “within blockquote”
+      "`);
+  });
+
+  it("at end before another paragraph", async () => {
+    const file = await process('"before paragraph"\n\nparagraph');
+    expect(file.toString()).toMatchInlineSnapshot(`
+      "“before paragraph”\n\nparagraph
+      "`);
+  });
+
+  it("at end before a blockquote", async () => {
+    const file = await process('"before blockquote"\n\n> blockquote');
+    expect(file.toString()).toMatchInlineSnapshot(`
+      "“before blockquote”\n\n> blockquote
       "`);
   });
 });

--- a/plugin.test.ts
+++ b/plugin.test.ts
@@ -60,11 +60,20 @@ describe("handles quotes around inline code", async () => {
   });
 });
 
-it("handles quotes after blockquotes", async () => {
-  const file = await process('> blockquote\n\n"after blockquote"');
-  expect(file.toString()).toMatchInlineSnapshot(`
-    "> blockquote\n\n“after blockquote”
-    "`);
+describe("handles quotes at the start of a paragraph", () => {
+  it("after paragraphs", async () => {
+    const file = await process('paragraph\n\n"after paragraph"');
+    expect(file.toString()).toMatchInlineSnapshot(`
+      "paragraph\n\n“after paragraph”
+      "`);
+  });
+
+  it("after a blockquote", async () => {
+    const file = await process('> blockquote\n\n"after blockquote"');
+    expect(file.toString()).toMatchInlineSnapshot(`
+      "> blockquote\n\n“after blockquote”
+      "`);
+  });
 });
 
 describe("should ignore parent nodes", () => {

--- a/plugin.test.ts
+++ b/plugin.test.ts
@@ -74,6 +74,13 @@ describe("handles quotes at the start of a paragraph", () => {
       "> blockquote\n\n“after blockquote”
       "`);
   });
+
+  it("within a blockquote", async () => {
+    const file = await process('> blockquote\n>\n> "within blockquote"');
+    expect(file.toString()).toMatchInlineSnapshot(`
+      "> blockquote\n>\n> “within blockquote”
+      "`);
+  });
 });
 
 describe("should ignore parent nodes", () => {


### PR DESCRIPTION
## Summary

[v2.1.0](https://github.com/silvenon/remark-smartypants/releases/tag/v2.1.0) fixed smart quotes around links and inline code by concatenating all text into one string (`allText`) and converting that with `retext-smartypants`.

That introduced a small regression. Quotes at the start of a paragraph may be merged with another paragraph, which `retext-smartypants` will no longer recognize as opening quotes. For instance:

```markdown
Hi there

"Some quote"
```

is incorrectly converted to:

```markdown
Hi there

”Some quote”
```

where the first quote on "Some quote" is being treated as a closing quote.

This PR fixes that by inserting a space into `allText` every time we see a `paragraph` node, then skipping over the inserted spaces when we need to keep track of indexes. That feels slightly clumsy, but it's a targeted way to fix this bug without changing the other behavior of this plugin.

## Test Plan

- Three new unit tests are introduced which fail without this change and succeed with it.
- All existing unit tests pass.